### PR TITLE
fix(validation): validate taproot address with regex, not just prefix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -755,8 +755,8 @@ export default {
           return json({ error: 'Required: btc_address, taproot_address' }, 400, origin);
         }
 
-        if (!body.taproot_address.startsWith('bc1p')) {
-          return json({ error: 'taproot_address must be a taproot address (bc1p...)' }, 400, origin);
+        if (!isValidBtcAddress(body.taproot_address) || !body.taproot_address.startsWith('bc1p')) {
+          return json({ error: 'taproot_address must be a valid taproot address (bc1p...)' }, 400, origin);
         }
 
         // Auth: require BIP-137 signature


### PR DESCRIPTION
## Summary

Fixes #17.

The `POST /api/agents/taproot` endpoint was checking taproot addresses with only a `startsWith('bc1p')` prefix check. This allowed malformed inputs like:

- `bc1p` (too short — only 4 chars)
- `bc1pINVALIDCHARS!!!` (invalid character set)
- Any string of any length starting with `bc1p`

## Fix

Adds a call to the existing `isValidBtcAddress()` function (line 48–50) **before** the prefix check:

```typescript
// Before (too lenient):
if (!body.taproot_address.startsWith('bc1p')) {

// After (regex + prefix):
if (!isValidBtcAddress(body.taproot_address) || !body.taproot_address.startsWith('bc1p')) {
```

`isValidBtcAddress()` uses the regex `/^(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,62}$/` which enforces:
- Correct base58/bech32 character set
- Minimum and maximum length (25–62 chars after prefix)

The prefix check is kept to ensure only taproot (`bc1p`) addresses are accepted, not SegWit (`bc1q`) or legacy (`1`/`3`) addresses.

## Test plan

- [ ] `bc1p` alone → rejected (too short)
- [ ] `bc1pINVALID!!!` → rejected (bad chars)
- [ ] Valid `bc1p...` taproot address → accepted
- [ ] `bc1q...` SegWit address → rejected by prefix check

🤖 Generated with [Claude Code](https://claude.com/claude-code)