### PR TITLE
fix: handle listing race condition with proper 409

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -930,13 +930,21 @@ export default {
         // Upsert seller agent
         await ensureAgent(env.DB, body.seller_btc_address, body.seller_display_name, body.seller_stx_address);
 
-        const result = await env.DB
-          .prepare(
-            `INSERT INTO listings (inscription_id, seller_btc_address, price_floor_sats, description)
-             VALUES (?, ?, ?, ?)`
-          )
-          .bind(body.inscription_id, body.seller_btc_address, body.price_floor_sats, body.description || null)
-          .run();
+        let result: any;
+        try {
+          result = await env.DB
+            .prepare(
+              `INSERT INTO listings (inscription_id, seller_btc_address, price_floor_sats, description)
+               VALUES (?, ?, ?, ?)`
+            )
+            .bind(body.inscription_id, body.seller_btc_address, body.price_floor_sats, body.description || null)
+            .run();
+        } catch (insertErr: any) {
+          if (insertErr?.message?.includes('UNIQUE constraint')) {
+            return json({ error: 'Active listing already exists for this inscription' }, 409, origin);
+          }
+          throw insertErr;
+        }
 
         if (!result.success) return json({ error: 'Database write failed' }, 500, origin);
 


### PR DESCRIPTION
Closes #18.

## Problem

`POST /api/listings` does a SELECT then INSERT. Between those two operations, a concurrent request can also pass the SELECT check and attempt the same INSERT. The DB unique index catches this correctly, but the error propagates as an unhandled exception and returns a generic 500.

## Fix (Option A from issue)

Wrap the INSERT in a nested try/catch:
- If the caught error message includes `'UNIQUE constraint'`, return `409` with the same user-facing message already used by the SELECT pre-check.
- Otherwise re-throw so the outer catch still returns a generic 500 for unexpected errors.

The existing SELECT pre-check is preserved as a fast path for the common (non-race) case.

## Changed file

`src/index.ts` — lines 933-947 (POST /api/listings handler)

```ts
let result: any;
try {
  result = await env.DB
    .prepare(
      `INSERT INTO listings (inscription_id, seller_btc_address, price_floor_sats, description)
       VALUES (?, ?, ?, ?)`
    )
    .bind(body.inscription_id, body.seller_btc_address, body.price_floor_sats, body.description || null)
    .run();
} catch (insertErr: any) {
  if (insertErr?.message?.includes('UNIQUE constraint')) {
    return json({ error: 'Active listing already exists for this inscription' }, 409, origin);
  }
  throw insertErr;
}
```