### PR TITLE
fix(db): wrap all D1 .run() calls with dbRun() to check success flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,16 @@ const MAX_DISPLAY_NAME = 50;
 const MAX_DESCRIPTION = 500;
 const MAX_METADATA = 1000;
 
+// --- D1 Helper ---
+
+async function dbRun(stmt: D1PreparedStatement): Promise<D1Result> {
+  const result = await stmt.run();
+  if (!result.success) {
+    throw new Error('Database operation failed');
+  }
+  return result;
+}
+
 // --- BIP-137 Signature Verification ---
 
 function encodeVarint(n: number): Uint8Array {
@@ -262,7 +272,7 @@ async function validateAuth(body: any): Promise<string | null> {
 }
 
 async function ensureAgent(db: D1Database, btcAddress: string, displayName?: string, stxAddress?: string, taprootAddress?: string) {
-  await db
+  await dbRun(db
     .prepare(
       `INSERT INTO agents (btc_address, display_name, stx_address, taproot_address) VALUES (?, ?, ?, ?)
        ON CONFLICT(btc_address) DO UPDATE SET
@@ -271,7 +281,7 @@ async function ensureAgent(db: D1Database, btcAddress: string, displayName?: str
          taproot_address = COALESCE(excluded.taproot_address, agents.taproot_address)`
     )
     .bind(btcAddress, displayName || null, stxAddress || null, taprootAddress || null)
-    .run();
+  );
 }
 
 // --- On-Chain Watcher ---
@@ -386,14 +396,14 @@ async function syncAgentsFromAibtc(db: D1Database): Promise<number> {
 
     for (const a of data.agents) {
       if (!a.btcAddress) continue;
-      await db
+      await dbRun(db
         .prepare(
           `INSERT INTO agents (btc_address, display_name, stx_address) VALUES (?, ?, ?)
            ON CONFLICT(btc_address) DO UPDATE SET
              display_name = COALESCE(agents.display_name, excluded.display_name),
              stx_address = COALESCE(excluded.stx_address, agents.stx_address)`)
         .bind(a.btcAddress, a.displayName || a.bnsName || null, a.stxAddress || null)
-        .run();
+      );
       synced++;
     }
 
@@ -415,9 +425,9 @@ async function runWatcher(env: Env): Promise<void> {
   if (inProgress) return;
 
   // Start run
-  const run = await db
+  const run = await dbRun(db
     .prepare("INSERT INTO watcher_runs (status) VALUES ('running')")
-    .run();
+  );
   const runId = run.meta.last_row_id;
 
   let agentsChecked = 0;
@@ -498,37 +508,37 @@ async function runWatcher(env: Env): Promise<void> {
 
               if (previousHolder) {
                 // Log as detected transfer
-                await db
+                await dbRun(db
                   .prepare(
                     `INSERT INTO trades (type, from_agent, to_agent, inscription_id, status, source, metadata)
                      VALUES ('transfer', ?, ?, ?, 'completed', 'watcher', 'Auto-detected by on-chain watcher')`
                   )
                   .bind(previousHolder, agent.btc_address, insc.id)
-                  .run();
+                );
 
                 // Update trade counts
-                await db.prepare('UPDATE agents SET trade_count = trade_count + 1 WHERE btc_address = ?').bind(previousHolder).run();
-                await db.prepare('UPDATE agents SET trade_count = trade_count + 1 WHERE btc_address = ?').bind(agent.btc_address).run();
+                await dbRun(db.prepare('UPDATE agents SET trade_count = trade_count + 1 WHERE btc_address = ?').bind(previousHolder));
+                await dbRun(db.prepare('UPDATE agents SET trade_count = trade_count + 1 WHERE btc_address = ?').bind(agent.btc_address));
 
                 transfersFound++;
               }
             }
 
             // Add to snapshot under primary btc_address (unified per agent)
-            await db
+            await dbRun(db
               .prepare('INSERT OR IGNORE INTO agent_inscriptions (btc_address, inscription_id) VALUES (?, ?)')
               .bind(agent.btc_address, insc.id)
-              .run();
+            );
           }
         }
 
         // Missing inscriptions = outgoing transfers — remove from snapshot
         for (const prev of snapshot.results) {
           if (!currentIds.has(prev.inscription_id)) {
-            await db
+            await dbRun(db
               .prepare('DELETE FROM agent_inscriptions WHERE btc_address = ? AND inscription_id = ?')
               .bind(agent.btc_address, prev.inscription_id)
-              .run();
+            );
           }
         }
       } catch (agentErr: any) {
@@ -542,23 +552,23 @@ async function runWatcher(env: Env): Promise<void> {
     }
 
     // Complete run
-    await db
+    await dbRun(db
       .prepare(
         "UPDATE watcher_runs SET status = 'completed', finished_at = datetime('now'), agents_checked = ?, transfers_found = ?, errors = ? WHERE id = ?"
       )
       .bind(agentsChecked, transfersFound, errors.length ? errors.join('; ') : null, runId)
-      .run();
+    );
   } catch (e: any) {
-    await db
+    await dbRun(db
       .prepare(
         "UPDATE watcher_runs SET status = 'error', finished_at = datetime('now'), agents_checked = ?, transfers_found = ?, errors = ? WHERE id = ?"
       )
       .bind(agentsChecked, transfersFound, e.message, runId)
-      .run();
+    );
   }
 
   // Cleanup: keep only the 100 most recent watcher_runs to prevent unbounded table growth
-  await db.prepare("DELETE FROM watcher_runs WHERE id NOT IN (SELECT id FROM watcher_runs ORDER BY id DESC LIMIT 100)").run();
+  await dbRun(db.prepare("DELETE FROM watcher_runs WHERE id NOT IN (SELECT id FROM watcher_runs ORDER BY id DESC LIMIT 100)"));
 }
 
 export default {
@@ -613,7 +623,7 @@ export default {
         if (body.type === 'psbt_swap') status = 'completed';
         if (body.type === 'cancel') status = 'cancelled';
 
-        const result = await env.DB
+        const result = await dbRun(env.DB
           .prepare(
             `INSERT INTO trades (type, from_agent, to_agent, inscription_id, amount_sats, status, tx_hash, parent_trade_id, metadata, source)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'manual')`
@@ -629,37 +639,35 @@ export default {
             body.parent_trade_id ?? null,
             body.metadata ?? null
           )
-          .run();
-
-        if (!result.success) return json({ error: 'Database write failed' }, 500, origin);
+        );
 
         // Update parent trade status if this is a counter/transfer/cancel
         if (body.parent_trade_id) {
           const parentStatus = body.type === 'counter' ? 'countered' : body.type === 'transfer' ? 'completed' : 'cancelled';
-          await env.DB
+          await dbRun(env.DB
             .prepare('UPDATE trades SET status = ?, updated_at = datetime(\'now\') WHERE id = ?')
             .bind(parentStatus, body.parent_trade_id)
-            .run();
+          );
         }
 
         // Auto-close marketplace listings when a psbt_swap or transfer completes for the same inscription
         if ((body.type === 'psbt_swap' || body.type === 'transfer') && body.inscription_id) {
-          await env.DB
+          await dbRun(env.DB
             .prepare("UPDATE listings SET status = 'sold', trade_id = ?, updated_at = datetime('now') WHERE inscription_id = ? AND status = 'active'")
             .bind(result.meta.last_row_id, body.inscription_id)
-            .run();
+          );
         }
 
         // Increment trade counts
-        await env.DB
+        await dbRun(env.DB
           .prepare('UPDATE agents SET trade_count = trade_count + 1 WHERE btc_address = ?')
           .bind(body.from_agent)
-          .run();
+        );
         if (body.to_agent) {
-          await env.DB
+          await dbRun(env.DB
             .prepare('UPDATE agents SET trade_count = trade_count + 1 WHERE btc_address = ?')
             .bind(body.to_agent)
-            .run();
+          );
         }
 
         return json({ success: true, trade_id: result.meta.last_row_id }, 201, origin);
@@ -790,10 +798,10 @@ export default {
         }
 
         // Update taproot address
-        await env.DB
+        await dbRun(env.DB
           .prepare('UPDATE agents SET taproot_address = ? WHERE btc_address = ?')
           .bind(body.taproot_address, body.btc_address)
-          .run();
+        );
 
         return json({ success: true, btc_address: body.btc_address, taproot_address: body.taproot_address }, 200, origin);
       } catch (e: any) {
@@ -930,23 +938,21 @@ export default {
         // Upsert seller agent
         await ensureAgent(env.DB, body.seller_btc_address, body.seller_display_name, body.seller_stx_address);
 
-        let result: any;
+        let result: D1Result;
         try {
-          result = await env.DB
+          result = await dbRun(env.DB
             .prepare(
               `INSERT INTO listings (inscription_id, seller_btc_address, price_floor_sats, description)
                VALUES (?, ?, ?, ?)`
             )
             .bind(body.inscription_id, body.seller_btc_address, body.price_floor_sats, body.description || null)
-            .run();
+          );
         } catch (insertErr: any) {
           if (insertErr?.message?.includes('UNIQUE constraint')) {
             return json({ error: 'Active listing already exists for this inscription' }, 409, origin);
           }
           throw insertErr;
         }
-
-        if (!result.success) return json({ error: 'Database write failed' }, 500, origin);
 
         return json({ success: true, listing_id: result.meta.last_row_id }, 201, origin);
       } catch (e: any) {
@@ -1047,10 +1053,10 @@ export default {
           return json({ error: 'Only the seller can update this listing' }, 403, origin);
         }
 
-        await env.DB
+        await dbRun(env.DB
           .prepare("UPDATE listings SET status = ?, trade_id = ?, updated_at = datetime('now') WHERE id = ?")
           .bind(body.status, body.trade_id || null, id)
-          .run();
+        );
 
         return json({ success: true }, 200, origin);
       } catch (e: any) {


### PR DESCRIPTION
## Summary

- Adds a `dbRun(stmt: D1PreparedStatement): Promise<D1Result>` helper near the top of `src/index.ts` that calls `.run()` and throws `Error('Database operation failed')` if `result.success` is false
- Replaces all ~20 bare `.run()` calls across every write path: `ensureAgent`, `syncAgentsFromAibtc`, `runWatcher`, `POST /api/trades`, `POST /api/agents/taproot`, `POST /api/listings`, and `PATCH /api/listings/:id`
- Removes the two manual `if (!result.success)` checks in `POST /api/trades` and `POST /api/listings` that were already there but inconsistent — `dbRun` now provides uniform coverage

## What changed in `src/index.ts`

New helper at line ~70:
```typescript
async function dbRun(stmt: D1PreparedStatement): Promise<D1Result> {
  const result = await stmt.run();
  if (!result.success) {
    throw new Error('Database operation failed');
  }
  return result;
}
```

Every INSERT/UPDATE/DELETE `.run()` call in request and scheduled handler functions is now wrapped. Schema creation statements in the scheduled handler are left as-is per the issue guidance.

## Test plan

- [ ] Deploy to Cloudflare Workers staging environment
- [ ] POST /api/trades with valid payload returns 201 and trade_id
- [ ] POST /api/listings with valid payload returns 201 and listing_id
- [ ] PATCH /api/listings/:id with valid delist payload returns 200
- [ ] POST /api/agents/taproot with valid payload returns 200
- [ ] Scheduled watcher run completes without error in wrangler dev

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)