### PR TITLE
fix(trades): add existence validation for parent_trade_id and listing trade_id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -616,6 +616,17 @@ export default {
           await ensureAgent(env.DB, body.to_agent, body.to_display_name, body.to_stx_address);
         }
 
+        // Validate parent_trade_id before inserting
+        if (body.parent_trade_id) {
+          if (body.type === 'offer' || body.type === 'psbt_swap') {
+            return json({ error: `Trade type '${body.type}' cannot reference a parent_trade_id` }, 400, origin);
+          }
+          const parent = await env.DB.prepare('SELECT id FROM trades WHERE id = ?').bind(body.parent_trade_id).first();
+          if (!parent) {
+            return json({ error: 'parent_trade_id does not exist' }, 400, origin);
+          }
+        }
+
         // Determine status based on type
         let status = 'open';
         if (body.type === 'counter') status = 'countered';
@@ -643,9 +654,6 @@ export default {
 
         // Update parent trade status if this is a counter or transfer
         if (body.parent_trade_id) {
-          if (body.type === 'offer' || body.type === 'psbt_swap') {
-            return json({ error: `Trade type '${body.type}' cannot reference a parent_trade_id` }, 400, origin);
-          }
           const parentStatus = body.type === 'counter' ? 'countered' : 'completed';
           await dbRun(env.DB
             .prepare('UPDATE trades SET status = ?, updated_at = datetime(\'now\') WHERE id = ?')
@@ -1054,6 +1062,13 @@ export default {
 
         if (listing.seller_btc_address !== body.seller_btc_address) {
           return json({ error: 'Only the seller can update this listing' }, 403, origin);
+        }
+
+        if (body.trade_id) {
+          const trade = await env.DB.prepare('SELECT id FROM trades WHERE id = ?').bind(body.trade_id).first();
+          if (!trade) {
+            return json({ error: 'trade_id does not exist' }, 400, origin);
+          }
         }
 
         await dbRun(env.DB


### PR DESCRIPTION
Closes #24

## Summary

- **POST /api/trades**: `parent_trade_id` type restriction and existence check are now validated **before** the `INSERT`. Previously the type check (`offer`/`psbt_swap` cannot reference a parent) ran _after_ the row was already written to the DB, and there was no existence check at all — a bogus `parent_trade_id` caused a silent 0-row UPDATE, leaving an orphaned child trade behind.
- **PATCH /api/listings/:id**: added a `trade_id` existence check before the `UPDATE`. Without it, a listing could be linked to a non-existent trade with no error.

## Changes

`/home/mars/ordinals-trade-ledger/src/index.ts` — one file changed, 18 insertions, 3 deletions.

**POST /api/trades** (before the `INSERT`):
```typescript
if (body.parent_trade_id) {
  if (body.type === 'offer' || body.type === 'psbt_swap') {
    return json({ error: `Trade type '${body.type}' cannot reference a parent_trade_id` }, 400, origin);
  }
  const parent = await env.DB.prepare('SELECT id FROM trades WHERE id = ?').bind(body.parent_trade_id).first();
  if (!parent) {
    return json({ error: 'parent_trade_id does not exist' }, 400, origin);
  }
}
```

**PATCH /api/listings/:id** (before the `UPDATE`):
```typescript
if (body.trade_id) {
  const trade = await env.DB.prepare('SELECT id FROM trades WHERE id = ?').bind(body.trade_id).first();
  if (!trade) {
    return json({ error: 'trade_id does not exist' }, 400, origin);
  }
}
```

## Test plan

- [ ] POST /api/trades with `parent_trade_id` pointing to a non-existent trade returns `400 { error: 'parent_trade_id does not exist' }` and no new row is written
- [ ] POST /api/trades with type `offer` or `psbt_swap` and any `parent_trade_id` returns `400` and no new row is written
- [ ] POST /api/trades with valid `parent_trade_id` still succeeds and updates parent status
- [ ] PATCH /api/listings/:id with `trade_id` pointing to a non-existent trade returns `400 { error: 'trade_id does not exist' }`
- [ ] PATCH /api/listings/:id with valid `trade_id` still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)