### PR TITLE
Add runtime validation for external API responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -345,6 +345,10 @@ async function fetchAgentInscriptions(address: string, unisatApiKey?: string): P
     if (!data.data?.inscription) break;
 
     for (const insc of data.data.inscription) {
+      if (!insc.inscriptionId || !isValidInscriptionId(insc.inscriptionId)) {
+        console.error(`Unisat: skipping entry with invalid inscriptionId: ${JSON.stringify(insc.inscriptionId)}`);
+        continue;
+      }
       all.push({
         id: insc.inscriptionId,
         number: insc.inscriptionNumber,
@@ -407,7 +411,10 @@ async function syncAgentsFromAibtc(db: D1Database): Promise<number> {
     if (!data.agents || data.agents.length === 0) break;
 
     for (const a of data.agents) {
-      if (!a.btcAddress) continue;
+      if (!a.btcAddress) {
+        console.error(`AIBTC agent sync: skipping agent without btcAddress: ${JSON.stringify(a)}`);
+        continue;
+      }
       await dbRun(db
         .prepare(
           `INSERT INTO agents (btc_address, display_name, stx_address) VALUES (?, ?, ?)
@@ -419,7 +426,7 @@ async function syncAgentsFromAibtc(db: D1Database): Promise<number> {
       synced++;
     }
 
-    if (!data.pagination.hasMore) break;
+    if (!data.pagination?.hasMore) break;
     offset += limit;
   }
 


### PR DESCRIPTION
Closes #29.

## What

Validates Unisat inscription responses and AIBTC agent sync data before DB insertion.

### Unisat inscription response (`fetchAgentInscriptions`)

Before storing each inscription, validate `inscriptionId` using the existing `isValidInscriptionId()` function. Entries with a missing or malformed `inscriptionId` are skipped with a `console.error` log rather than being pushed to the accumulator array.

### AIBTC agent sync (`syncAgentsFromAibtc`)

- Skip agents missing `btcAddress` and log the skipped entry via `console.error` (previously `continue` with no log)
- Use optional chaining (`data.pagination?.hasMore`) to guard against response shapes where `pagination` is absent, preventing an uncaught TypeError that would break the sync loop

## Why

Without these guards:
- A Unisat entry with a null/garbage `inscriptionId` could be stored and later fail foreign-key or format checks in trade records
- An AIBTC response missing the `pagination` key would throw at `data.pagination.hasMore` and abort the entire sync silently (caught by the outer `resp.ok` check only on the *next* request)

## Changes

- `src/index.ts`: +9 lines, -2 lines — validation only, no logic changes