### PR TITLE
fix(watcher): eliminate TOCTOU race in transfer detection (closes #23)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -514,28 +514,27 @@ async function runWatcher(env: Env): Promise<void> {
         // New inscriptions = incoming transfers
         for (const insc of allInscriptions) {
           if (!previousIds.has(insc.id)) {
-            // Check dedup: no matching trade in last 24h for this inscription+agent
-            const existing = await db
-              .prepare(
-                "SELECT id FROM trades WHERE inscription_id = ? AND to_agent = ? AND created_at > datetime('now', '-1 day')"
-              )
-              .bind(insc.id, agent.btc_address)
-              .first();
+            const previousHolder = await findPreviousHolder(db, insc.id, agent.btc_address);
 
-            if (!existing) {
-              const previousHolder = await findPreviousHolder(db, insc.id, agent.btc_address);
+            if (previousHolder) {
+              // Fix for TOCTOU race condition (issue #23): use a single atomic
+              // INSERT ... SELECT WHERE NOT EXISTS statement so the duplicate
+              // check and the insert happen together without a gap that a
+              // concurrent manual POST /api/trades could exploit.
+              const insertResult = await db
+                .prepare(
+                  `INSERT INTO trades (type, from_agent, to_agent, inscription_id, status, source, metadata)
+                   SELECT 'transfer', ?, ?, ?, 'completed', 'watcher', 'Auto-detected by on-chain watcher'
+                   WHERE NOT EXISTS (
+                     SELECT 1 FROM trades
+                     WHERE inscription_id = ? AND to_agent = ? AND created_at > datetime('now', '-1 day')
+                   )`
+                )
+                .bind(previousHolder, agent.btc_address, insc.id, insc.id, agent.btc_address)
+                .run();
 
-              if (previousHolder) {
-                // Log as detected transfer
-                await dbRun(db
-                  .prepare(
-                    `INSERT INTO trades (type, from_agent, to_agent, inscription_id, status, source, metadata)
-                     VALUES ('transfer', ?, ?, ?, 'completed', 'watcher', 'Auto-detected by on-chain watcher')`
-                  )
-                  .bind(previousHolder, agent.btc_address, insc.id)
-                );
-
-                // Update trade counts
+              if (insertResult.meta.rows_written > 0) {
+                // Update trade counts only when the insert actually happened
                 await dbRun(db.prepare('UPDATE agents SET trade_count = trade_count + 1 WHERE btc_address = ?').bind(previousHolder));
                 await dbRun(db.prepare('UPDATE agents SET trade_count = trade_count + 1 WHERE btc_address = ?').bind(agent.btc_address));
 


### PR DESCRIPTION
## Summary

- Replaces the two-step SELECT-then-INSERT dedup check in the watcher's transfer detection with a single atomic `INSERT ... SELECT WHERE NOT EXISTS` SQL statement
- The old code had a TOCTOU window between checking for existing trades (line 518) and inserting the new one (line 530), during which a concurrent manual `POST /api/trades` could create a duplicate/conflicting transfer record for the same inscription
- The new single-statement approach makes the check and insert indivisible at the SQLite level — no gap for a race

## What changed

File: `src/index.ts`, lines 514-551 (watcher transfer detection loop)

Before:
```ts
const existing = await db.prepare("SELECT id FROM trades WHERE ...").first();
if (!existing) {
  await dbRun(db.prepare("INSERT INTO trades ...").bind(...));
}
```

After:
```ts
const insertResult = await db
  .prepare(`INSERT INTO trades (...) SELECT ... WHERE NOT EXISTS (SELECT 1 FROM trades WHERE ...)`)
  .bind(...)
  .run();
if (insertResult.meta.rows_written > 0) { /* update counts */ }
```

`rows_written` from `D1Meta` is used to detect whether the insert was skipped (duplicate found) or succeeded.

## Test plan

- [ ] Deploy to staging and trigger the watcher manually while sending concurrent `POST /api/trades` requests for the same inscription
- [ ] Verify only one transfer record is created per inscription per 24h window
- [ ] Verify `trade_count` increments only when the insert actually happened

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)