### PR TITLE
fix(security): add ownership check to cancel/counter endpoints (#33)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -641,9 +641,17 @@ export default {
           if (body.type === 'offer' || body.type === 'psbt_swap') {
             return json({ error: `Trade type '${body.type}' cannot reference a parent_trade_id` }, 400, origin);
           }
-          const parent = await env.DB.prepare('SELECT id FROM trades WHERE id = ?').bind(body.parent_trade_id).first();
+          const parent = await env.DB.prepare('SELECT id, from_agent, to_agent FROM trades WHERE id = ?').bind(body.parent_trade_id).first() as { id: number; from_agent: string; to_agent: string | null } | null;
           if (!parent) {
             return json({ error: 'parent_trade_id does not exist' }, 400, origin);
+          }
+          // Ownership check: only the seller (from_agent) or buyer (to_agent) of the parent trade
+          // may cancel or counter it. Any other agent is rejected with 403.
+          if (body.type === 'cancel' || body.type === 'counter') {
+            const caller = body.from_agent;
+            if (caller !== parent.from_agent && caller !== parent.to_agent) {
+              return json({ error: 'Forbidden: only a party to the original trade may cancel or counter it' }, 403, origin);
+            }
           }
         }
 


### PR DESCRIPTION
## Summary

Fixes #33 — missing authorization check on cancel and counter trade operations.

- **Before:** any agent could POST `type: cancel` or `type: counter` with any `parent_trade_id`, allowing them to cancel or counter-offer a trade they were not party to. BIP-137 auth only proved identity, not authorization.
- **After:** the parent trade lookup now fetches `from_agent` and `to_agent`. For `cancel` and `counter` operations, the caller is checked against both fields. If the caller is neither the seller nor the buyer, the request is rejected with `403 Forbidden: only a party to the original trade may cancel or counter it`.

## Changed file

`/src/index.ts` — `POST /api/trades` handler, parent trade validation block (line ~644):

```diff
-  const parent = await env.DB.prepare('SELECT id FROM trades WHERE id = ?').bind(body.parent_trade_id).first();
+  const parent = await env.DB.prepare('SELECT id, from_agent, to_agent FROM trades WHERE id = ?').bind(body.parent_trade_id).first() as { id: number; from_agent: string; to_agent: string | null } | null;
   if (!parent) {
     return json({ error: 'parent_trade_id does not exist' }, 400, origin);
   }
+  // Ownership check: only the seller (from_agent) or buyer (to_agent) of the parent trade
+  // may cancel or counter it. Any other agent is rejected with 403.
+  if (body.type === 'cancel' || body.type === 'counter') {
+    const caller = body.from_agent;
+    if (caller !== parent.from_agent && caller !== parent.to_agent) {
+      return json({ error: 'Forbidden: only a party to the original trade may cancel or counter it' }, 403, origin);
+    }
+  }
```

## Test plan

- [ ] Agent A creates an offer (type: `offer`) → gets `trade_id: 42`
- [ ] Agent B (the buyer, `to_agent`) counters trade 42 → succeeds (200/201)
- [ ] Agent A (the seller) cancels trade 42 → succeeds (200/201)
- [ ] Agent C (unrelated) tries to cancel trade 42 → gets `403 Forbidden`
- [ ] Agent C (unrelated) tries to counter trade 42 → gets `403 Forbidden`
- [ ] Existing `transfer` type with `parent_trade_id` is unaffected (no ownership check added for transfers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)