### PR TITLE
fix(security): enforce body size limit on actual content, not just header (#34)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,15 +66,36 @@ const MAX_DESCRIPTION = 500;
 const MAX_METADATA = 1000;
 
 const MAX_BODY_SIZE = 1024 * 1024; // 1MB
-function checkBodySize(request: Request): Response | null {
-  const contentLength = parseInt(request.headers.get('content-length') || '0');
-  if (contentLength > MAX_BODY_SIZE) {
-    return new Response(JSON.stringify({ error: 'Request body too large' }), {
+const TOO_LARGE_RESPONSE = JSON.stringify({ error: 'Request body too large' });
+
+// Returns the raw body text, or a 413 Response if the body exceeds MAX_BODY_SIZE.
+// Content-Length is used as a fast-path early rejection, but the actual byte
+// length of the body is always checked regardless of whether the header is present
+// (e.g. chunked transfer encoding omits Content-Length, which previously allowed
+// arbitrarily large payloads to bypass this guard — see issue #34).
+async function readBodyWithSizeCheck(request: Request): Promise<{ error: Response } | { text: string }> {
+  // Fast-path: reject immediately when Content-Length header is present and already
+  // exceeds the limit, saving us from buffering an oversized body at all.
+  const contentLengthHeader = request.headers.get('content-length');
+  if (contentLengthHeader !== null) {
+    const declared = parseInt(contentLengthHeader, 10);
+    if (!isNaN(declared) && declared > MAX_BODY_SIZE) {
+      return { error: new Response(TOO_LARGE_RESPONSE, {
+        status: 413,
+        headers: { 'Content-Type': 'application/json' }
+      }) };
+    }
+  }
+
+  // Read the actual body and enforce the limit on real byte length.
+  const text = await request.text();
+  if (new TextEncoder().encode(text).length > MAX_BODY_SIZE) {
+    return { error: new Response(TOO_LARGE_RESPONSE, {
       status: 413,
       headers: { 'Content-Type': 'application/json' }
-    });
+    }) };
   }
-  return null;
+  return { text };
 }
 
 // --- D1 Helper ---
@@ -605,9 +626,9 @@ export default {
     // POST /api/trades — Log a new trade event
     if (request.method === 'POST' && path === '/api/trades') {
       try {
-        const sizeError = checkBodySize(request);
-        if (sizeError) return sizeError;
-        const body = (await request.json()) as TradeInput & { signature?: string; timestamp?: string };
+        const bodyResult = await readBodyWithSizeCheck(request);
+        if ('error' in bodyResult) return bodyResult.error;
+        const body = JSON.parse(bodyResult.text) as TradeInput & { signature?: string; timestamp?: string };
 
         if (!body.type || !body.from_agent || !body.inscription_id) {
           return json({ error: 'Missing required fields: type, from_agent, inscription_id' }, 400, origin);
@@ -791,9 +812,9 @@ export default {
     // POST /api/agents/taproot — Register a taproot address for an agent
     if (request.method === 'POST' && path === '/api/agents/taproot') {
       try {
-        const sizeError = checkBodySize(request);
-        if (sizeError) return sizeError;
-        const body = await request.json() as {
+        const bodyResult = await readBodyWithSizeCheck(request);
+        if ('error' in bodyResult) return bodyResult.error;
+        const body = JSON.parse(bodyResult.text) as {
           btc_address?: string;
           taproot_address?: string;
           signature?: string;
@@ -918,9 +939,9 @@ export default {
     // POST /api/listings — Create a new listing (list an ordinal for sale)
     if (request.method === 'POST' && path === '/api/listings') {
       try {
-        const sizeError = checkBodySize(request);
-        if (sizeError) return sizeError;
-        const body = await request.json() as any;
+        const bodyResult = await readBodyWithSizeCheck(request);
+        if ('error' in bodyResult) return bodyResult.error;
+        const body = JSON.parse(bodyResult.text) as any;
 
         if (!body.inscription_id || !body.seller_btc_address || !body.price_floor_sats) {
           return json({ error: 'Required: inscription_id, seller_btc_address, price_floor_sats' }, 400, origin);
@@ -1054,9 +1075,9 @@ export default {
     if (request.method === 'PATCH' && path.match(/^\/api\/listings\/\d+$/)) {
       try {
         const id = parseInt(path.split('/').pop()!);
-        const sizeError = checkBodySize(request);
-        if (sizeError) return sizeError;
-        const body = await request.json() as any;
+        const bodyResult = await readBodyWithSizeCheck(request);
+        if ('error' in bodyResult) return bodyResult.error;
+        const body = JSON.parse(bodyResult.text) as any;
 
         if (!body.status || !['delisted', 'sold'].includes(body.status)) {
           return json({ error: 'status must be "delisted" or "sold"' }, 400, origin);


### PR DESCRIPTION
## Summary

Fixes #34 — `checkBodySize` was bypassable when the `Content-Length` header was absent.

- **Root cause:** The old `checkBodySize` function read only the `Content-Length` request header to enforce the 1 MB body size limit. Requests sent with chunked transfer encoding (or any request that simply omits the header) had no `Content-Length`, so the check fell through with `parseInt('0')` and the full — potentially unbounded — body was accepted and parsed.
- **Fix:** Replace `checkBodySize` with an async `readBodyWithSizeCheck` that always reads and measures the real body bytes, regardless of header presence.
- **No regression on the fast path:** When `Content-Length` _is_ present and already exceeds the limit, the body is rejected immediately without buffering it.

## What changed (`src/index.ts`)

- Removed `checkBodySize(request: Request): Response | null` (sync, header-only).
- Added `readBodyWithSizeCheck(request: Request): Promise<{ error: Response } | { text: string }>` (async):
  1. If `Content-Length` header is present and declared size exceeds 1 MB → return 413 immediately (fast path, no buffering).
  2. Read the body via `request.text()`.
  3. Measure actual byte length with `TextEncoder`.
  4. If over limit → return 413.
  5. Otherwise → return `{ text }` so the caller can `JSON.parse()` it directly (a `Request` body stream can only be consumed once, so returning the text avoids a second read).
- Updated all four call sites (POST `/api/trades`, POST `/api/agents/taproot`, POST `/api/listings`, PATCH `/api/listings/:id`) to use the new function.

## Test plan

- [ ] Send a POST to `/api/trades` **without** a `Content-Length` header and a body > 1 MB — should receive `413 Request body too large`.
- [ ] Send a POST to `/api/trades` with chunked transfer encoding and a body > 1 MB — should receive `413`.
- [ ] Send a POST to `/api/trades` with a valid small body and no `Content-Length` — should be accepted normally.
- [ ] Send a POST to `/api/trades` with `Content-Length` header present and body > 1 MB — should still receive `413` (existing fast-path behavior preserved).
- [ ] Verify all four affected endpoints behave consistently.

Generated with [Claude Code](https://claude.com/claude-code)