### PR TITLE
fix(security): validate addresses from external API before inserting (#37)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -422,8 +422,9 @@ async function findPreviousHolder(db: D1Database, inscriptionId: string, current
   return null;
 }
 
-async function syncAgentsFromAibtc(db: D1Database): Promise<number> {
+async function syncAgentsFromAibtc(db: D1Database): Promise<{ synced: number; skipped: number }> {
   let synced = 0;
+  let skipped = 0;
   let offset = 0;
   const limit = 100;
 
@@ -439,10 +440,20 @@ async function syncAgentsFromAibtc(db: D1Database): Promise<number> {
     if (!data.agents || data.agents.length === 0) break;
 
     for (const a of data.agents) {
-      if (!a.btcAddress) {
-        console.error(`AIBTC agent sync: skipping agent without btcAddress: ${JSON.stringify(a)}`);
+      // Validate BTC address before inserting — reject missing or malformed addresses
+      if (!a.btcAddress || !isValidBtcAddress(a.btcAddress)) {
+        console.error(`AIBTC agent sync: skipping agent with invalid btcAddress: ${JSON.stringify(a)}`);
+        skipped++;
         continue;
       }
+
+      // Validate STX address when present — reject malformed values rather than storing them
+      if (a.stxAddress && !isValidStxAddress(a.stxAddress)) {
+        console.error(`AIBTC agent sync: skipping agent with invalid stxAddress: ${JSON.stringify(a)}`);
+        skipped++;
+        continue;
+      }
+
       await dbRun(db
         .prepare(
           `INSERT INTO agents (btc_address, display_name, stx_address) VALUES (?, ?, ?)
@@ -458,7 +469,7 @@ async function syncAgentsFromAibtc(db: D1Database): Promise<number> {
     offset += limit;
   }
 
-  return synced;
+  return { synced, skipped };
 }
 
 async function runWatcher(env: Env): Promise<void> {
@@ -486,7 +497,10 @@ async function runWatcher(env: Env): Promise<void> {
     const runCount = await db.prepare('SELECT COUNT(*) as c FROM watcher_runs').first<{ c: number }>();
     if ((runCount?.c || 0) % 6 === 1) {
       try {
-        await syncAgentsFromAibtc(db);
+        const syncResult = await syncAgentsFromAibtc(db);
+        if (syncResult.skipped > 0) {
+          console.warn(`AIBTC agent sync: inserted ${syncResult.synced}, skipped ${syncResult.skipped} agents with invalid addresses`);
+        }
       } catch (syncErr: any) {
         errors.push(`aibtc sync: ${syncErr.message}`);
       }


### PR DESCRIPTION
## Summary

Fixes #37.

- `syncAgentsFromAibtc` now calls `isValidBtcAddress()` on every BTC address from the AIBTC API before inserting into D1
- It also calls `isValidStxAddress()` on every STX address when one is present
- Agents with invalid addresses are skipped, counted, and logged via `console.error`
- The caller in `runWatcher` logs a warning summary if any agents were skipped

## Problem

The function previously only checked `if (!a.btcAddress)` (truthy check), which would pass an empty string but reject `undefined`/`null`. It did not validate the address format at all. A compromised or buggy AIBTC API could have inserted malformed BTC or STX addresses into the local D1 database, poisoning lookups and potentially causing incorrect trade ledger entries.

## Approach

- Reuses the existing `isValidBtcAddress()` and `isValidStxAddress()` helpers already used in request validation elsewhere in the codebase — no new dependencies
- Changed return type from `Promise<number>` to `Promise<{ synced: number; skipped: number }>` to expose the skip count to the caller for observability
- Invalid addresses are logged at `console.error` level with the full raw agent payload to aid debugging

## Test plan

- [ ] Deploy to staging and trigger a watcher run — confirm `synced` count in logs matches expected agent count
- [ ] Temporarily inject a mock agent with `btcAddress: "not-an-address"` and confirm it is skipped and logged
- [ ] Confirm STX address `SP...` valid entries still insert correctly
- [ ] Confirm a malformed STX address (e.g. `"stxAddress": "0xinvalid"`) is rejected and counted

🤖 Generated with [Claude Code](https://claude.com/claude-code)