### PR TITLE
fix(auth): signature replay protection — store sig hash in D1, reject 409 on duplicate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -303,10 +303,47 @@ async function verifyBip137(signature: string, message: string, expectedAddress:
   return null; // verified
 }
 
+// --- Signature Replay Protection ---
+
+/** SHA-256 hex digest of an arbitrary string — used as the stored sig_hash key. */
+async function sha256Hex(input: string): Promise<string> {
+  const bytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(bytes), b => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Attempt to record a signature as used.
+ * Returns null on success, or an error string if the signature was already used.
+ * The INSERT is a no-op on conflict (PRIMARY KEY), so concurrent races safely
+ * resolve to one winner and one loser rather than silently double-inserting.
+ */
+async function recordSignatureUse(db: D1Database, sigHash: string): Promise<string | null> {
+  const result = await db
+    .prepare('INSERT OR IGNORE INTO used_signatures (sig_hash) VALUES (?)')
+    .bind(sigHash)
+    .run();
+  // rows_written === 0 means the hash already existed → replay detected
+  if (result.meta.rows_written === 0) {
+    return 'Signature already used — replay detected (409 Conflict)';
+  }
+  return null;
+}
+
+/**
+ * Delete used_signatures rows older than 24 hours.
+ * Called lazily on each POST /api/trades and by the scheduled cron handler
+ * so the table never grows without bound.
+ */
+async function cleanupExpiredSignatures(db: D1Database): Promise<void> {
+  await db
+    .prepare("DELETE FROM used_signatures WHERE used_at < datetime('now', '-1 day')")
+    .run();
+}
+
 // Auth: require BIP-137 signature on all write endpoints
 // Signature message format: "ordinals-ledger | {type} | {from_agent} | {inscription_id} | {timestamp}"
 // Timestamp must be within 300 seconds of server time
-async function validateAuth(body: any): Promise<string | null> {
+async function validateAuth(body: any, db: D1Database): Promise<string | null> {
   if (!body.from_agent) return 'Required: from_agent';
   if (!isValidBtcAddress(body.from_agent)) return 'Invalid from_agent: must be a valid Bitcoin address';
   if (body.to_agent && !isValidBtcAddress(body.to_agent)) return 'Invalid to_agent: must be a valid Bitcoin address';
@@ -347,6 +384,15 @@ async function validateAuth(body: any): Promise<string | null> {
   const expectedMessage = `ordinals-ledger | ${body.type} | ${body.from_agent} | ${body.inscription_id || ''} | ${body.timestamp}`;
   const sigErr = await verifyBip137(body.signature, expectedMessage, body.from_agent);
   if (sigErr) return sigErr;
+
+  // Replay protection: hash the raw signature and attempt to record it as used.
+  // recordSignatureUse returns an error string if the hash already exists in D1
+  // (i.e., this exact signature was already accepted), which causes the request to
+  // be rejected with 409 Conflict from the caller. Cleanup of entries older than
+  // 24h is done lazily here so the table stays bounded without a separate job.
+  await cleanupExpiredSignatures(db);
+  const replayErr = await recordSignatureUse(db, await sha256Hex(body.signature));
+  if (replayErr) return replayErr;
 
   return null;
 }
@@ -711,8 +757,13 @@ export default {
           return json({ error: 'Invalid type. Must be: offer, counter, transfer, cancel, psbt_swap' }, 400, corsOrigin);
         }
 
-        const authErr = await validateAuth(body as any);
-        if (authErr) return json({ error: authErr }, 401, corsOrigin);
+        const authErr = await validateAuth(body as any, env.DB);
+        if (authErr) {
+          // Replay protection violations are surfaced as 409 Conflict, all other
+          // auth failures use 401 Unauthorized.
+          const status = authErr.includes('replay detected') ? 409 : 401;
+          return json({ error: authErr }, status, corsOrigin);
+        }
 
         // Validate amount_sats if provided — must be a non-negative integer within BTC supply
         if (body.amount_sats !== undefined && body.amount_sats !== null) {
@@ -1225,7 +1276,14 @@ export default {
   },
 
   async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext) {
-    ctx.waitUntil(runWatcher(env));
+    // Run the on-chain watcher and clean up expired signature replay records
+    // together in each cron tick (every 5 minutes per wrangler.toml).
+    ctx.waitUntil(
+      Promise.all([
+        runWatcher(env),
+        cleanupExpiredSignatures(env.DB),
+      ])
+    );
   },
 };
 

--- a/src/migration-004.sql
+++ b/src/migration-004.sql
@@ -1,0 +1,10 @@
+-- Migration 004: Signature replay protection
+-- Stores a hash of each accepted BIP-137 signature to prevent replay attacks.
+-- Signatures are rejected if the same signature is submitted more than once
+-- within 24 hours. Expired entries (older than 24h) are cleaned up lazily on
+-- each trade submission and by the scheduled watcher cron.
+
+CREATE TABLE IF NOT EXISTS used_signatures (
+  sig_hash TEXT PRIMARY KEY,
+  used_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -47,6 +47,15 @@ CREATE TABLE IF NOT EXISTS watcher_runs (
   errors TEXT
 );
 
+-- Signature replay protection: stores a hash of each accepted BIP-137 signature.
+-- Prevents the same signed message from being replayed to create duplicate trades.
+-- Entries older than 24h are cleaned up lazily on each trade submission and by
+-- the scheduled watcher cron.
+CREATE TABLE IF NOT EXISTS used_signatures (
+  sig_hash TEXT PRIMARY KEY,
+  used_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 CREATE INDEX IF NOT EXISTS idx_trades_type ON trades(type);
 CREATE INDEX IF NOT EXISTS idx_trades_from ON trades(from_agent);
 CREATE INDEX IF NOT EXISTS idx_trades_to ON trades(to_agent);


### PR DESCRIPTION
## Summary

Fixes #45 — **CRITICAL: Signature replay attack**.

The same BIP-137 signed message could be submitted multiple times to create
duplicate trades. The 5-minute timestamp window reduced but did not eliminate
the window because:

1. An attacker could replay the same signed request multiple times within
   the 5-minute window.
2. A buggy or malicious client could resubmit successful requests on error.

### What changed

- **`src/migration-004.sql`** — new migration adding `used_signatures` table:
  ```sql
  CREATE TABLE IF NOT EXISTS used_signatures (
    sig_hash TEXT PRIMARY KEY,
    used_at TEXT NOT NULL DEFAULT (datetime('now'))
  );
  ```
- **`src/schema.sql`** — same table added to the full schema for fresh deploys.
- **`src/index.ts`** — three new helpers + wire-up in `validateAuth` and the cron:
  - `sha256Hex(input)` — Web Crypto SHA-256 digest, no extra deps.
  - `recordSignatureUse(db, sigHash)` — `INSERT OR IGNORE`; returns an error
    string when `rows_written === 0` (hash already existed). Atomic at SQLite
    level — safe under concurrent requests.
  - `cleanupExpiredSignatures(db)` — deletes rows older than 24 h. Called
    lazily on every `POST /api/trades` and in the cron handler.
  - `validateAuth` now takes `db: D1Database`; after BIP-137 cryptographic
    verification passes, cleanup runs then the signature hash is recorded.
  - `POST /api/trades` returns **409 Conflict** on replay, **401** for other
    auth errors.

### Why this approach

- No new dependencies — uses `crypto.subtle.digest` available in all CF Workers.
- Replay check is after cryptographic verification, so malformed signatures
  cannot pollute the table.
- `INSERT OR IGNORE` makes the check-and-insert atomic at the DB layer,
  eliminating the TOCTOU race that a separate SELECT + INSERT would have.
- Lazy cleanup on every request plus cron cleanup keeps table size bounded
  without needing a separate scheduled task.

## Test plan

- [ ] Deploy migration-004.sql: `wrangler d1 execute ordinals-trade-ledger --remote --file=src/migration-004.sql`
- [ ] Submit a valid trade — should return 201 as before.
- [ ] Replay the exact same request immediately — should return 409 Conflict with `"Signature already used — replay detected (409 Conflict)"`.
- [ ] Wait 5+ minutes and replay — should still return 409 (signature hash still in table for 24h).
- [ ] Submit a new trade with a fresh signature and updated timestamp — should succeed.
- [ ] Verify `used_signatures` table is pruned by the cron after 24h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)