### PR TITLE
Fix 3 HIGH security issues: JSON.parse safety + replay protection + taproot migration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1060,12 +1060,13 @@ export default {
       try {
         const bodyResult = await readBodyWithSizeCheck(request);
         if ('error' in bodyResult) return bodyResult.error;
-        const body = JSON.parse(bodyResult.text) as {
-          btc_address?: string;
-          taproot_address?: string;
-          signature?: string;
-          timestamp?: string;
-        };
+
+        let body: { btc_address?: string; taproot_address?: string; signature?: string; timestamp?: string };
+        try {
+          body = JSON.parse(bodyResult.text);
+        } catch {
+          return json({ error: 'Invalid JSON in request body' }, 400, corsOrigin);
+        }
 
         if (!body.btc_address || !body.taproot_address) {
           return json({ error: 'Required: btc_address, taproot_address' }, 400, corsOrigin);
@@ -1093,6 +1094,13 @@ export default {
         const taprootMsg = `ordinals-ledger | taproot | ${body.btc_address} | ${body.taproot_address} | ${body.timestamp}`;
         const taprootSigErr = await verifyBip137(body.signature, taprootMsg, body.btc_address);
         if (taprootSigErr) return json({ error: taprootSigErr }, 401, corsOrigin);
+
+        // Replay protection: reject signatures that have already been used.
+        // Cleanup of entries older than 24h is done lazily so the table stays bounded.
+        await cleanupExpiredSignatures(env.DB);
+        const sigHash = await sha256Hex(body.signature!);
+        const replayErr = await recordSignatureUse(env.DB, sigHash);
+        if (replayErr) return json({ error: replayErr }, 409, corsOrigin);
 
         // Check agent exists
         const agent = await env.DB
@@ -1323,7 +1331,13 @@ export default {
         const id = parseInt(path.split('/').pop()!);
         const bodyResult = await readBodyWithSizeCheck(request);
         if ('error' in bodyResult) return bodyResult.error;
-        const body = JSON.parse(bodyResult.text) as any;
+
+        let body: any;
+        try {
+          body = JSON.parse(bodyResult.text);
+        } catch {
+          return json({ error: 'Invalid JSON in request body' }, 400, corsOrigin);
+        }
 
         if (!body.status || !['delisted', 'sold'].includes(body.status)) {
           return json({ error: 'status must be "delisted" or "sold"' }, 400, corsOrigin);

--- a/src/migration-006.sql
+++ b/src/migration-006.sql
@@ -1,0 +1,5 @@
+-- Migration 006: Add taproot_address column to agents table
+-- Enables agents to register a P2TR (bc1p...) address alongside their SegWit
+-- address for inscription scanning and taproot-native asset tracking.
+
+ALTER TABLE agents ADD COLUMN taproot_address TEXT;


### PR DESCRIPTION
## Summary

Self-audit cycle #53 identified three HIGH-severity security issues in `src/index.ts`. This PR fixes all three and adds the missing schema migration.

### Fix 1 — Unguarded `JSON.parse` in `POST /api/agents/taproot` (HIGH)

**Before:** `const body = JSON.parse(bodyResult.text) as { ... }` — a malformed request body throws an uncaught `SyntaxError` inside the outer `try/catch`, which returns a generic `500 Internal Server Error` and leaks a stack frame through the error message.

**After:** Wrapped in an inner `try/catch` that returns `{ error: 'Invalid JSON in request body' }` with status `400`. Matches the pattern already used in `POST /api/trades` (~line 866).

### Fix 2 — Unguarded `JSON.parse` in `PATCH /api/listings/:id` (HIGH)

Same issue: `const body = JSON.parse(bodyResult.text) as any` was not wrapped.

**After:** Same `try/catch` pattern — `400` with `'Invalid JSON in request body'`.

### Fix 3 — Missing replay protection in `POST /api/agents/taproot` (HIGH)

**Before:** The endpoint verifies a BIP-137 signature via `verifyBip137()` but never calls `recordSignatureUse()`. A valid `(signature, timestamp)` pair captured once could be replayed hundreds of times within the 5-minute timestamp window, allowing an attacker to spam taproot address registrations on behalf of any agent.

**After:** Added `cleanupExpiredSignatures` + `recordSignatureUse` immediately after `verifyBip137` succeeds, returning `409 Conflict` on replay — identical to the pattern in `POST /api/trades` (~lines 499–501).

### Fix 4 — Add `migration-006.sql` (schema hygiene, partially closes #53)

The `taproot_address` column is referenced throughout `index.ts` (`ensureAgent`, `GET /api/agents`, `/api/stats`, watcher cron) but was never formally added via a migration file. Added `src/migration-006.sql` with `ALTER TABLE agents ADD COLUMN taproot_address TEXT`.

## Files changed

- `src/index.ts` — fixes 1, 2, 3
- `src/migration-006.sql` — new migration for `taproot_address` column

## Test plan

- [ ] `POST /api/agents/taproot` with body `not-json` returns `400 { error: 'Invalid JSON in request body' }`
- [ ] `PATCH /api/listings/1` with body `not-json` returns `400 { error: 'Invalid JSON in request body' }`
- [ ] `POST /api/agents/taproot` with a valid signature replayed a second time returns `409 Conflict`
- [ ] `POST /api/agents/taproot` with a fresh valid signature still returns `200`
- [ ] `wrangler d1 execute ordinals-trade-ledger --file=src/migration-006.sql` runs without error

Partially closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)