### PR TITLE
Fix POST /api/trades: allow null-Origin (curl/agent) requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,9 @@ const WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
  */
 function resolveCorsOrigin(requestOrigin: string | null, isWrite: boolean): string | null {
   if (!isWrite) return '*';
-  if (!requestOrigin) return null;
+  // No Origin header = not a browser request (curl, agent, server-to-server) = safe to allow.
+  // CORS restrictions only apply to browser cross-origin requests.
+  if (!requestOrigin) return '*';
 
   // Allow exact production origins
   if ((WRITE_ALLOWED_ORIGINS as string[]).includes(requestOrigin)) return requestOrigin;


### PR DESCRIPTION
## Problem
`POST /api/trades` returned `{"error":"Origin not allowed"}` (HTTP 403) for all non-browser callers including `curl` and agent-to-agent API calls.

## Root Cause
`resolveCorsOrigin()` returned `null` when the request had no `Origin` header, causing the `json()` helper to emit a 403 with no CORS headers.

Non-browser clients (curl, server-to-server, autonomous agents) never send an `Origin` header — this is not a cross-origin security risk. CORS restrictions exist to protect browsers from malicious third-party sites; they don't apply to direct API calls.

## Fix
When `requestOrigin` is `null` (no Origin header), return `'*'` instead of `null`. Browser-originated write requests are still restricted to `WRITE_ALLOWED_ORIGINS`.

## Test
```bash
curl -X POST https://ledger.drx4.xyz/api/trades \
  -H "Content-Type: application/json" \
  -d '{"type":"offer","from_agent":"bc1q...","inscription_id":"test","signature":"test"}'
# Before: {"error":"Origin not allowed"}
# After:  {"error":"Invalid inscription_id: must be {64-hex-txid}i{number}"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)