### PR TITLE
fix: normalize legacy trade source values (closes #62)

### DIFF
--- a/src/migration-007.sql
+++ b/src/migration-007.sql
@@ -1,0 +1,53 @@
+-- Migration 007: Normalize legacy trade source values
+-- Trades 1-5 were inserted before field validation; their source column
+-- contains raw timestamps (e.g. "2026-02-17 04:38:37") instead of valid
+-- enum values. This migration corrects them to 'manual' and adds a CHECK
+-- constraint to prevent future bad data.
+-- Closes #62
+
+-- Step 1: Fix malformed source values (timestamps) -> 'manual'
+UPDATE trades
+  SET source = 'manual',
+      updated_at = datetime('now')
+  WHERE source NOT IN ('watcher', 'manual', 'api');
+
+-- Step 2: Recreate the trades table with a CHECK constraint on source.
+-- D1/SQLite does not support ALTER TABLE ... ADD CONSTRAINT, so we use
+-- the standard rename-copy-drop pattern.
+
+-- 2a. Rename old table
+ALTER TABLE trades RENAME TO trades_old;
+
+-- 2b. Create new table with CHECK constraint on source
+CREATE TABLE trades (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  type TEXT NOT NULL CHECK (type IN ('offer', 'counter', 'transfer', 'cancel', 'psbt_swap')),
+  from_agent TEXT NOT NULL,
+  to_agent TEXT,
+  inscription_id TEXT NOT NULL,
+  amount_sats INTEGER,
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'countered', 'accepted', 'completed', 'cancelled')),
+  tx_hash TEXT,
+  parent_trade_id INTEGER REFERENCES trades(id),
+  metadata TEXT,
+  source TEXT DEFAULT 'manual' CHECK (source IN ('watcher', 'manual', 'api')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (from_agent) REFERENCES agents(btc_address),
+  FOREIGN KEY (to_agent) REFERENCES agents(btc_address)
+);
+
+-- 2c. Copy all rows (source values already normalized in Step 1)
+INSERT INTO trades
+  SELECT * FROM trades_old;
+
+-- 2d. Drop the old table
+DROP TABLE trades_old;
+
+-- 2e. Re-create indexes (dropped with the old table)
+CREATE INDEX IF NOT EXISTS idx_trades_type ON trades(type);
+CREATE INDEX IF NOT EXISTS idx_trades_from ON trades(from_agent);
+CREATE INDEX IF NOT EXISTS idx_trades_to ON trades(to_agent);
+CREATE INDEX IF NOT EXISTS idx_trades_inscription ON trades(inscription_id);
+CREATE INDEX IF NOT EXISTS idx_trades_status ON trades(status);
+CREATE INDEX IF NOT EXISTS idx_trades_created ON trades(created_at DESC);

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS trades (
   tx_hash TEXT,
   parent_trade_id INTEGER REFERENCES trades(id),
   metadata TEXT,
-  source TEXT DEFAULT 'manual',
+  source TEXT DEFAULT 'manual' CHECK (source IN ('watcher', 'manual', 'api')),
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now')),
   FOREIGN KEY (from_agent) REFERENCES agents(btc_address),


### PR DESCRIPTION
## Summary

- **Normalizes malformed `source` values** in trades 1-5 from timestamps (e.g. `"2026-02-17 04:38:37"`) to `'manual'`
- **Adds a CHECK constraint** on the `source` column to enforce valid enum values (`watcher`, `manual`, `api`) going forward
- **Updates `schema.sql`** to reflect the new constraint for fresh deployments

## Details

Trades 1-5 were inserted before field validation existed on the `source` column, so they ended up with raw timestamp strings. This migration:

1. Updates any row whose `source` is not in the allowed set to `'manual'`
2. Recreates the `trades` table with `CHECK (source IN ('watcher', 'manual', 'api'))` using the standard SQLite rename-copy-drop pattern (same approach as migration-002)
3. Re-creates all indexes that were dropped with the old table

### Files changed
- `src/migration-007.sql` — new D1 migration
- `src/schema.sql` — added CHECK constraint on `source` column

## Test plan
- [ ] Run migration-007 against a local D1 database with `wrangler d1 execute`
- [ ] Verify trades 1-5 now have `source = 'manual'`
- [ ] Verify inserting a trade with an invalid source value is rejected
- [ ] Verify inserting trades with `watcher`, `manual`, or `api` source values succeeds

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)