### PR TITLE
fix: accept BIP-322 signatures for bc1q addresses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -306,6 +306,262 @@ async function verifyBip137(signature: string, message: string, expectedAddress:
   return null; // verified
 }
 
+// --- BIP-322 Simple Signature Verification (P2WPKH / bc1q) ---
+
+function bip322TaggedHash(message: string): Uint8Array {
+  const tag = sha256(new TextEncoder().encode('BIP0322-signed-message'));
+  const msgBytes = new TextEncoder().encode(message);
+  const buf = new Uint8Array(tag.length + tag.length + msgBytes.length);
+  buf.set(tag, 0);
+  buf.set(tag, tag.length);
+  buf.set(msgBytes, tag.length * 2);
+  return sha256(buf);
+}
+
+function writeUint32LE(value: number): Uint8Array {
+  const buf = new Uint8Array(4);
+  buf[0] = value & 0xff;
+  buf[1] = (value >>> 8) & 0xff;
+  buf[2] = (value >>> 16) & 0xff;
+  buf[3] = (value >>> 24) & 0xff;
+  return buf;
+}
+
+function writeUint64LE(value: number): Uint8Array {
+  const buf = new Uint8Array(8);
+  buf[0] = value & 0xff;
+  buf[1] = (value >>> 8) & 0xff;
+  buf[2] = (value >>> 16) & 0xff;
+  buf[3] = (value >>> 24) & 0xff;
+  // high 32 bits are 0 for values we use
+  return buf;
+}
+
+function concatBytes(...arrays: Uint8Array[]): Uint8Array {
+  const total = arrays.reduce((sum, a) => sum + a.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const a of arrays) {
+    result.set(a, offset);
+    offset += a.length;
+  }
+  return result;
+}
+
+function doubleSha256(data: Uint8Array): Uint8Array {
+  return sha256(sha256(data));
+}
+
+/**
+ * Decode a bech32/bech32m address and return the witness version and program bytes.
+ */
+function decodeBech32Address(addr: string): { version: number; program: Uint8Array } | null {
+  const lowerAddr = addr.toLowerCase();
+  const pos = lowerAddr.lastIndexOf('1');
+  if (pos < 1) return null;
+  const hrp = lowerAddr.slice(0, pos);
+  if (hrp !== 'bc') return null;
+
+  const CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+  const dataChars = lowerAddr.slice(pos + 1);
+  const data: number[] = [];
+  for (const c of dataChars) {
+    const idx = CHARSET.indexOf(c);
+    if (idx === -1) return null;
+    data.push(idx);
+  }
+
+  // Verify checksum (bech32 for v0, bech32m for v1+)
+  const expand = [...Array.from(hrp, c => c.charCodeAt(0) >> 5), 0, ...Array.from(hrp, c => c.charCodeAt(0) & 31)];
+  const values = [...expand, ...data];
+  const polymod = bech32Polymod(values);
+  const version = data[0];
+  const expectedPolymod = version === 0 ? 1 : 0x2bc830a3;
+  if (polymod !== expectedPolymod) return null;
+
+  // Strip witness version and checksum
+  const payload = data.slice(1, data.length - 6);
+  // Convert from 5-bit to 8-bit
+  let acc = 0, bits = 0;
+  const program: number[] = [];
+  for (const val of payload) {
+    acc = (acc << 5) | val;
+    bits += 5;
+    while (bits >= 8) {
+      bits -= 8;
+      program.push((acc >> bits) & 0xff);
+    }
+  }
+  return { version, program: new Uint8Array(program) };
+}
+
+async function verifyBip322(signature: string, message: string, expectedAddress: string): Promise<string | null> {
+  let sigBytes: Uint8Array;
+  try {
+    sigBytes = Uint8Array.from(atob(signature), c => c.charCodeAt(0));
+  } catch { return 'Invalid BIP-322 signature: not valid base64'; }
+
+  // Parse witness stack: first byte = number of witness items (must be 0x02)
+  if (sigBytes.length < 3 || sigBytes[0] !== 0x02) {
+    return 'Invalid BIP-322 signature: expected 2 witness items';
+  }
+
+  // Read DER signature (with sighash byte appended)
+  let offset = 1;
+  const derLen = sigBytes[offset];
+  offset += 1;
+  if (offset + derLen > sigBytes.length) return 'Invalid BIP-322 signature: DER length overflow';
+  const derSigWithHashType = sigBytes.slice(offset, offset + derLen);
+  offset += derLen;
+
+  // Read compressed pubkey (33 bytes, preceded by length byte 0x21)
+  if (offset >= sigBytes.length) return 'Invalid BIP-322 signature: missing pubkey';
+  const pubkeyLen = sigBytes[offset];
+  offset += 1;
+  if (pubkeyLen !== 0x21) return `Invalid BIP-322 signature: expected 33-byte pubkey, got length ${pubkeyLen}`;
+  if (offset + 33 > sigBytes.length) return 'Invalid BIP-322 signature: pubkey truncated';
+  const pubkey = sigBytes.slice(offset, offset + 33);
+
+  // Verify pubkey hashes to the witness program of the expected bc1q address
+  const decoded = decodeBech32Address(expectedAddress);
+  if (!decoded || decoded.version !== 0 || decoded.program.length !== 20) {
+    return 'BIP-322 verification only supports P2WPKH (bc1q) addresses';
+  }
+
+  const pubkeyHash = ripemd160(sha256(pubkey));
+  const expectedHash = decoded.program;
+  if (pubkeyHash.length !== expectedHash.length || !pubkeyHash.every((b, i) => b === expectedHash[i])) {
+    return 'BIP-322 verification failed: pubkey does not match address';
+  }
+
+  // Strip sighash type byte from DER signature
+  const sighashType = derSigWithHashType[derSigWithHashType.length - 1];
+  if (sighashType !== 0x01) return `Invalid BIP-322 signature: unexpected sighash type ${sighashType}`;
+  const derSig = derSigWithHashType.slice(0, derSigWithHashType.length - 1);
+
+  // Parse DER signature to extract r, s
+  // DER format: 0x30 [total-len] 0x02 [r-len] [r] 0x02 [s-len] [s]
+  let sig: secp.Signature;
+  try {
+    if (derSig[0] !== 0x30) throw new Error('not DER');
+    let pos = 2; // skip 0x30 and total length
+    if (derSig[pos] !== 0x02) throw new Error('missing r integer tag');
+    pos++;
+    const rLen = derSig[pos]; pos++;
+    const rBytes = derSig.slice(pos, pos + rLen); pos += rLen;
+    if (derSig[pos] !== 0x02) throw new Error('missing s integer tag');
+    pos++;
+    const sLen = derSig[pos]; pos++;
+    const sBytes = derSig.slice(pos, pos + sLen);
+    // Convert to BigInt (DER integers are big-endian, potentially with leading zero for sign)
+    const rHex = Array.from(rBytes, b => b.toString(16).padStart(2, '0')).join('');
+    const sHex = Array.from(sBytes, b => b.toString(16).padStart(2, '0')).join('');
+    sig = new secp.Signature(BigInt('0x' + rHex), BigInt('0x' + sHex));
+  } catch { return 'Invalid BIP-322 signature: DER parsing failed'; }
+
+  // --- Construct the "to_spend" transaction ---
+  const messageChallenge = bip322TaggedHash(message);
+
+  // scriptSig for to_spend input: OP_0 OP_PUSH32 <message_challenge>
+  const scriptSig = new Uint8Array(34);
+  scriptSig[0] = 0x00; // OP_0
+  scriptSig[1] = 0x20; // OP_PUSH32
+  scriptSig.set(messageChallenge, 2);
+
+  // P2WPKH scriptPubKey for to_spend output: OP_0 OP_PUSH20 <hash160(pubkey)>
+  const scriptPubKey = new Uint8Array(22);
+  scriptPubKey[0] = 0x00; // OP_0
+  scriptPubKey[1] = 0x14; // OP_PUSH20
+  scriptPubKey.set(pubkeyHash, 2);
+
+  const toSpend = concatBytes(
+    writeUint32LE(0),                   // version = 0
+    new Uint8Array([0x01]),             // 1 input
+    new Uint8Array(32),                 // txid = 0x00...00 (32 zero bytes)
+    writeUint32LE(0xFFFFFFFF),          // vout = 0xFFFFFFFF
+    encodeVarint(scriptSig.length),     // scriptSig length
+    scriptSig,                          // scriptSig
+    writeUint32LE(0),                   // sequence = 0
+    new Uint8Array([0x01]),             // 1 output
+    writeUint64LE(0),                   // value = 0
+    encodeVarint(scriptPubKey.length),  // scriptPubKey length
+    scriptPubKey,                       // scriptPubKey
+    writeUint32LE(0)                    // locktime = 0
+  );
+
+  const toSpendTxid = doubleSha256(toSpend);
+
+  // --- Compute BIP-143 sighash for to_sign transaction ---
+
+  // scriptCode for P2WPKH: OP_DUP OP_HASH160 OP_PUSH20 <hash160> OP_EQUALVERIFY OP_CHECKSIG
+  const scriptCode = new Uint8Array(25);
+  scriptCode[0] = 0x76; // OP_DUP
+  scriptCode[1] = 0xa9; // OP_HASH160
+  scriptCode[2] = 0x14; // OP_PUSH20
+  scriptCode.set(pubkeyHash, 3);
+  scriptCode[23] = 0x88; // OP_EQUALVERIFY
+  scriptCode[24] = 0xac; // OP_CHECKSIG
+
+  // hashPrevouts = SHA256(SHA256(outpoint)) where outpoint = toSpendTxid + vout(0)
+  const outpoint = concatBytes(toSpendTxid, writeUint32LE(0));
+  const hashPrevouts = doubleSha256(outpoint);
+
+  // hashSequence = SHA256(SHA256(sequence)) where sequence = 0
+  const hashSequence = doubleSha256(writeUint32LE(0));
+
+  // hashOutputs = SHA256(SHA256(output)) where output = value(0) + scriptPubKey(OP_RETURN)
+  const toSignOutput = concatBytes(
+    writeUint64LE(0),                   // value = 0
+    new Uint8Array([0x01, 0x6a])        // scriptPubKey = OP_RETURN (length 1, then 0x6a)
+  );
+  const hashOutputs = doubleSha256(toSignOutput);
+
+  // BIP-143 preimage
+  const sighashPreimage = concatBytes(
+    writeUint32LE(0),                   // version = 0
+    hashPrevouts,                       // hashPrevouts
+    hashSequence,                       // hashSequence
+    outpoint,                           // outpoint being signed
+    encodeVarint(scriptCode.length),    // scriptCode length
+    scriptCode,                         // scriptCode
+    writeUint64LE(0),                   // amount = 0
+    writeUint32LE(0),                   // sequence = 0
+    hashOutputs,                        // hashOutputs
+    writeUint32LE(0),                   // locktime = 0
+    writeUint32LE(1)                    // sighash type = SIGHASH_ALL
+  );
+
+  const sighash = doubleSha256(sighashPreimage);
+
+  // Verify ECDSA signature against the sighash
+  const isValid = secp.verify(sig, sighash, pubkey);
+  if (!isValid) return 'BIP-322 signature verification failed';
+
+  return null; // verified
+}
+
+/**
+ * Detect signature format and route to the appropriate verifier.
+ * BIP-137: base64-decoded is exactly 65 bytes.
+ * BIP-322 simple (P2WPKH): base64-decoded starts with 0x02 (2 witness items) and is longer.
+ */
+async function verifySig(signature: string, message: string, expectedAddress: string): Promise<string | null> {
+  let sigBytes: Uint8Array;
+  try {
+    sigBytes = Uint8Array.from(atob(signature), c => c.charCodeAt(0));
+  } catch { return 'Invalid signature: not valid base64'; }
+
+  if (sigBytes.length === 65) {
+    return verifyBip137(signature, message, expectedAddress);
+  }
+
+  if (sigBytes.length > 65 && sigBytes[0] === 0x02) {
+    return verifyBip322(signature, message, expectedAddress);
+  }
+
+  return `Unrecognized signature format: ${sigBytes.length} bytes`;
+}
+
 // --- Signature Replay Protection ---
 
 /** SHA-256 hex digest of an arbitrary string — used as the stored sig_hash key. */
@@ -448,7 +704,7 @@ async function cleanupExpiredRateLimits(db: D1Database): Promise<void> {
     .run();
 }
 
-// Auth: require BIP-137 signature on all write endpoints
+// Auth: require BIP-137 or BIP-322 signature on all write endpoints
 // Signature message format: "ordinals-ledger | {type} | {from_agent} | {inscription_id} | {timestamp}"
 // Timestamp must be within 300 seconds of server time
 async function validateAuth(body: any, db: D1Database): Promise<string | null> {
@@ -462,12 +718,12 @@ async function validateAuth(body: any, db: D1Database): Promise<string | null> {
   if (body.from_display_name && body.from_display_name.length > MAX_DISPLAY_NAME) return `from_display_name exceeds ${MAX_DISPLAY_NAME} chars`;
   if (body.to_display_name && body.to_display_name.length > MAX_DISPLAY_NAME) return `to_display_name exceeds ${MAX_DISPLAY_NAME} chars`;
   if (body.metadata && body.metadata.length > MAX_METADATA) return `metadata exceeds ${MAX_METADATA} chars`;
-  if (!body.signature) return 'Required: signature (BIP-137 signed message)';
+  if (!body.signature) return 'Required: signature (BIP-137 or BIP-322 signed message)';
   if (!body.timestamp) return 'Required: timestamp (ISO 8601)';
 
-  // Validate signature format (base64-encoded BIP-137 = 88 chars)
-  if (typeof body.signature !== 'string' || body.signature.length < 80 || body.signature.length > 100) {
-    return 'Invalid signature format (expected base64 BIP-137, ~88 chars)';
+  // Validate signature format (BIP-137 ~88 chars, BIP-322 ~130-160 chars)
+  if (typeof body.signature !== 'string' || body.signature.length < 80 || body.signature.length > 300) {
+    return 'Invalid signature format (expected base64 BIP-137 or BIP-322)';
   }
 
   // Validate timestamp is recent (within 300 seconds)
@@ -488,9 +744,9 @@ async function validateAuth(body: any, db: D1Database): Promise<string | null> {
     return 'PSBT swaps require to_agent (the counterparty)';
   }
 
-  // Cryptographic BIP-137 signature verification
+  // Cryptographic signature verification (BIP-137 or BIP-322)
   const expectedMessage = `ordinals-ledger | ${body.type} | ${body.from_agent} | ${body.inscription_id || ''} | ${body.timestamp}`;
-  const sigErr = await verifyBip137(body.signature, expectedMessage, body.from_agent);
+  const sigErr = await verifySig(body.signature, expectedMessage, body.from_agent);
   if (sigErr) return sigErr;
 
   // Replay protection: hash the raw signature and attempt to record it as used.
@@ -1078,9 +1334,9 @@ export default {
           return json({ error: 'taproot_address must be a valid taproot address (bc1p...)' }, 400, corsOrigin);
         }
 
-        // Auth: require BIP-137 signature
+        // Auth: require signed message (BIP-137 or BIP-322)
         if (!body.signature || !body.timestamp) {
-          return json({ error: 'Required: signature (BIP-137), timestamp (ISO 8601)' }, 401, corsOrigin);
+          return json({ error: 'Required: signature (BIP-137 or BIP-322), timestamp (ISO 8601)' }, 401, corsOrigin);
         }
 
         const ts = new Date(body.timestamp).getTime();
@@ -1088,13 +1344,13 @@ export default {
           return json({ error: 'Timestamp expired or invalid (must be within 300s)' }, 401, corsOrigin);
         }
 
-        if (typeof body.signature !== 'string' || body.signature.length < 80 || body.signature.length > 100) {
+        if (typeof body.signature !== 'string' || body.signature.length < 80 || body.signature.length > 300) {
           return json({ error: 'Invalid signature format' }, 401, corsOrigin);
         }
 
-        // Cryptographic BIP-137 verification
+        // Cryptographic signature verification (BIP-137 or BIP-322)
         const taprootMsg = `ordinals-ledger | taproot | ${body.btc_address} | ${body.taproot_address} | ${body.timestamp}`;
-        const taprootSigErr = await verifyBip137(body.signature, taprootMsg, body.btc_address);
+        const taprootSigErr = await verifySig(body.signature, taprootMsg, body.btc_address);
         if (taprootSigErr) return json({ error: taprootSigErr }, 401, corsOrigin);
 
         // Replay protection: reject signatures that have already been used.
@@ -1274,9 +1530,9 @@ export default {
           return json({ error: 'price_floor_sats exceeds maximum (21M BTC)' }, 400, corsOrigin);
         }
 
-        // Auth: seller must sign
+        // Auth: seller must sign (BIP-137 or BIP-322)
         if (!body.signature || !body.timestamp) {
-          return json({ error: 'Required: signature (BIP-137), timestamp (ISO 8601)' }, 401, corsOrigin);
+          return json({ error: 'Required: signature (BIP-137 or BIP-322), timestamp (ISO 8601)' }, 401, corsOrigin);
         }
 
         const ts = new Date(body.timestamp).getTime();
@@ -1284,13 +1540,13 @@ export default {
           return json({ error: 'Timestamp expired or invalid (must be within 300s)' }, 401, corsOrigin);
         }
 
-        if (typeof body.signature !== 'string' || body.signature.length < 80 || body.signature.length > 100) {
+        if (typeof body.signature !== 'string' || body.signature.length < 80 || body.signature.length > 300) {
           return json({ error: 'Invalid signature format' }, 401, corsOrigin);
         }
 
-        // Cryptographic BIP-137 verification for listings
+        // Cryptographic signature verification for listings (BIP-137 or BIP-322)
         const listingMsg = `ordinals-ledger | listing | ${body.seller_btc_address} | ${body.inscription_id} | ${body.timestamp}`;
-        const listingSigErr = await verifyBip137(body.signature, listingMsg, body.seller_btc_address);
+        const listingSigErr = await verifySig(body.signature, listingMsg, body.seller_btc_address);
         if (listingSigErr) return json({ error: listingSigErr }, 401, corsOrigin);
 
         // Check no active listing for same inscription by same seller
@@ -1406,13 +1662,13 @@ export default {
           return json({ error: 'Timestamp expired or invalid' }, 401, corsOrigin);
         }
 
-        if (typeof body.signature !== 'string' || body.signature.length < 80 || body.signature.length > 100) {
+        if (typeof body.signature !== 'string' || body.signature.length < 80 || body.signature.length > 300) {
           return json({ error: 'Invalid signature format' }, 401, corsOrigin);
         }
 
-        // Cryptographic BIP-137 verification
+        // Cryptographic signature verification (BIP-137 or BIP-322)
         const delistMsg = `ordinals-ledger | delist | ${body.seller_btc_address} | ${id} | ${body.timestamp}`;
-        const delistSigErr = await verifyBip137(body.signature, delistMsg, body.seller_btc_address);
+        const delistSigErr = await verifySig(body.signature, delistMsg, body.seller_btc_address);
         if (delistSigErr) return json({ error: delistSigErr }, 401, corsOrigin);
 
         // Verify listing exists and seller matches


### PR DESCRIPTION
## Summary

Fixes #64 — POST /api/trades (and other authenticated endpoints) now accept BIP-322 simple signatures from `bc1q` (P2WPKH / native SegWit) addresses, in addition to the existing BIP-137 format.

The standard MCP `btc_sign_message` tool produces BIP-322 witness-serialized signatures for `bc1q` addresses. These are longer than BIP-137 signatures (~130-160 base64 chars vs ~88) and use a completely different verification algorithm. Previously, these were rejected by both the signature length check and the BIP-137-only verification path, meaning bc1q agents could not authenticate.

### Changes

- **`verifyBip322()`** — New function implementing full BIP-322 simple verification for P2WPKH:
  - Parses the witness stack (DER signature + compressed pubkey)
  - Validates pubkey hashes to the witness program of the claimed bc1q address
  - Constructs the BIP-322 "to_spend" transaction with tagged message hash
  - Computes BIP-143 sighash for the "to_sign" transaction
  - Verifies the ECDSA signature against the sighash
- **`verifySig()`** — New dispatcher that detects signature format and routes:
  - 65 bytes decoded → BIP-137 (existing path)
  - Longer + starts with `0x02` → BIP-322 simple (new path)
- **Signature length check** — Widened from `(80, 100)` to `(80, 300)` on all 4 authenticated endpoints
- **All authenticated endpoints updated** to use `verifySig()` instead of `verifyBip137()` directly:
  - `POST /api/trades` (via `validateAuth()`)
  - `POST /api/agents/taproot`
  - `POST /api/listings`
  - `PATCH /api/listings/:id`

### What's preserved

- Existing BIP-137 verification is completely untouched — no behavioral changes for legacy/P2PKH/P2SH addresses
- No new dependencies added — uses existing `@noble/secp256k1`, `@noble/hashes/sha256`, and `@noble/hashes/ripemd160`
- Replay protection, timestamp validation, and all other auth checks remain unchanged

## Test plan

- [ ] Verify existing BIP-137 signatures (from `1...`, `3...`, and `bc1q...` addresses using BIP-137 format) continue to work
- [ ] Test BIP-322 signature from a `bc1q` address against `POST /api/trades`
- [ ] Test BIP-322 signature against `POST /api/agents/taproot`, `POST /api/listings`, `PATCH /api/listings/:id`
- [ ] Verify invalid/malformed BIP-322 signatures are rejected with clear error messages
- [ ] Verify replay protection still works for BIP-322 signatures
- [ ] Verify signature length boundaries: signatures < 80 chars or > 300 chars are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)