### PR TITLE
fix(migrations): normalize legacy source values in trades table

### DIFF
--- a/src/migration-007.sql
+++ b/src/migration-007.sql
@@ -1,0 +1,6 @@
+-- Migration 007: Normalize legacy source values in trades table
+-- Trades 1-5 had `source` set to timestamp strings (e.g. "2026-02-17 04:38:37")
+-- instead of valid enum values ("watcher", "manual", "api").
+-- This migration corrects those rows by mapping timestamp-like source values to "manual".
+
+UPDATE trades SET source = 'manual' WHERE source LIKE '20%-%-%';


### PR DESCRIPTION
## Summary

- Adds `src/migration-007.sql` to fix issue #62
- Trades 1-5 had `source` set to timestamp strings (e.g. `"2026-02-17 04:38:37"`) instead of valid enum values (`"watcher"`, `"manual"`, `"api"`)
- The migration updates all rows matching `LIKE '20%-%-%'` to set `source = 'manual'`, which is the appropriate fallback for pre-watcher trades entered via the API or seeded directly

## Migration

```sql
-- Migration 007: Normalize legacy source values in trades table
UPDATE trades SET source = 'manual' WHERE source LIKE '20%-%-%';
```

## Test plan

- [ ] Verify `SELECT * FROM trades WHERE id IN (1,2,3,4,5)` shows `source = 'manual'` after applying migration
- [ ] Verify no trades with valid source values (`watcher`, `manual`, `api`) are affected
- [ ] Run `wrangler d1 execute <DB> --file=src/migration-007.sql` in staging before production

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)