### PR TITLE
fix: normalise legacy trades with malformed source values

### DIFF
--- a/src/migration-007.sql
+++ b/src/migration-007.sql
@@ -1,0 +1,10 @@
+-- Migration 007: Fix legacy trades with malformed source values
+-- Trades 1-5 were inserted before source validation was added and have
+-- timestamp strings (e.g., "2026-02-17 04:38:37") instead of valid enum
+-- values. This migration normalises them to 'manual' (the default).
+
+UPDATE trades
+SET source = 'manual',
+    updated_at = datetime('now')
+WHERE id <= 5
+  AND source NOT IN ('watcher', 'manual', 'api');


### PR DESCRIPTION
## Summary
- Migration 007: updates trades 1-5 that have timestamp strings in `source` column to `'manual'`
- These were inserted before source validation existed in the codebase

Closes #62

## Deployment
After merge, run migration manually:
```bash
wrangler d1 execute ordinals-trade-ledger --file src/migration-007.sql
```

## Test plan
- [ ] Verify migration updates only trades with id <= 5 and non-enum source values
- [ ] Confirm existing trades with valid source values are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)